### PR TITLE
Level 04: Remove the reference to "switches"

### DIFF
--- a/levels/01 Basics/level04.html
+++ b/levels/01 Basics/level04.html
@@ -1,7 +1,7 @@
 
 <p>Computers are usually not connected directly, but are accessible through a series of <strong>routers</strong>.
 A router operates much like a postal office. When it receives a <strong>packet</strong>, it looks at the destination
-and determines which route to send it on. Switches usually choose the route that is closest to the destination
+and determines which route to send it on. They usually choose the route that is closest to the destination
 computer. They keep track of all their routes in a <strong>routing table</strong>.
 <p>Pause the simulation and look at one of the packets. It contains only the srcip and dstip headers we saw in the
 earlier levels. There is no extra information to tell the routers how to send the packet. Instead, this information


### PR DESCRIPTION
I don't think that the term "switches" is appropriate in this context. Looks like a left-over from a different wording/task.